### PR TITLE
fix missing quotation mark

### DIFF
--- a/usd/19.11/package.py
+++ b/usd/19.11/package.py
@@ -2,7 +2,7 @@
 
 name = 'usd'
 
-version = '19.11.3
+version = '19.11.3'
 
 requires = [
     'alembic-1.5',


### PR DESCRIPTION
fixed a small syntax error I've encountered while playing around with this repo:
```sh
me@carrotwo:~/dev/rez-cook (main)$ rez search usd
15:41:37 ERROR    ResourceError: Problem loading /home/me/dev/open-source-rez-packages/usd/19.11/package.py: unterminated string literal (detected at line 5) (package.py, line 5)
```